### PR TITLE
Allow for spacing in COMMAND[] Action

### DIFF
--- a/src/main/java/net/gravitydevelopment/anticheat/event/PlayerListener.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/event/PlayerListener.java
@@ -322,7 +322,7 @@ public class PlayerListener extends EventListener {
                     log(result.getMessage(), player, CheckType.FLY);
                 }
             }
-            if (getCheckManager().willCheckQuick(player, CheckType.VCLIP) && event.getFrom().getY() > event.getTo().getY()) {
+            if (getCheckManager().willCheckQuick(player, CheckType.VCLIP) && event.getFrom().getY() > event.getTo().getY() && event.getTo().getY() > 0) {
                 CheckResult result = getBackend().checkVClip(player, new Distance(event.getFrom(), event.getTo()));
                 if (result.failed()) {
                     if (!silentMode()) {

--- a/src/main/java/net/gravitydevelopment/anticheat/util/Group.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/util/Group.java
@@ -64,12 +64,11 @@ public class Group {
 
     public static Group load(String string) {
         try {
-            if (string.split(":").length == 4) {
-                string = Utilities.removeWhitespace(string);
-                String name = string.split(":")[0];
-                int level = Integer.parseInt(string.split(":")[1]);
-                String color = string.split(":")[2];
-                List<String> actions = Arrays.asList(string.split(":")[3].split(","));
+            if (string.split(" : ").length == 4) {
+                String name = string.split(" : ")[0];
+                int level = Integer.parseInt(string.split(" : ")[1]);
+                String color = string.split(" : ")[2];
+                List<String> actions = Arrays.asList(string.split(" : ")[3].split(","));
                 return new Group(name, level, color, actions);
             } else {
                 throw new Exception();


### PR DESCRIPTION
Since the whitespace is removed on the entire group string, the COMMAND action is pretty much unusable. Since you cannot have spaces, something like "COMMAND[ban &player]" would be converted to "COMMAND[ban&player]" and "ban&player" is not a command.
